### PR TITLE
  📝 작업 내역: chat 앱 기본 API 구현

### DIFF
--- a/chat/serializers.py
+++ b/chat/serializers.py
@@ -1,0 +1,28 @@
+from rest_framework import serializers
+from .models import ChatSession, ChatLog
+
+
+class ChatSessionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ChatSession
+        fields = ['id', 'user', 'title', 'created_at']
+        read_only_fields = ['user']  # user는 요청 시 자동으로 설정
+
+
+class ChatLogSerializer(serializers.ModelSerializer):
+    # session 필드는 id 값으로 입력을 받기 위해 PrimaryKeyRelatedField를 사용합니다.
+    session = serializers.PrimaryKeyRelatedField(queryset=ChatSession.objects.all())
+
+    class Meta:
+        model = ChatLog
+        # API를 통해 입력을 받을 필드들
+        fields = ['id', 'session', 'message', 'sender', 'timestamp']
+        # 서버에서 자동으로 설정할 필드들
+        read_only_fields = ['user', 'sender', 'timestamp']
+
+    def validate_session(self, value):
+        """세션이 현재 로그인한 사용자의 소유인지 확인"""
+        if value.user != self.context['request'].user:
+            raise serializers.ValidationError("You do not have permission to post to this chat session.")
+        return value
+

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import ChatSessionListCreateView, ChatMessageListCreateView
+
+urlpatterns = [
+    path('session', ChatSessionListCreateView.as_view(), name='chat-session-list-create'),
+    path('message', ChatMessageListCreateView.as_view(), name='chat-message-list-create'),
+]

--- a/chat/views.py
+++ b/chat/views.py
@@ -1,3 +1,45 @@
-from django.shortcuts import render
+from rest_framework import generics, permissions
+from rest_framework.exceptions import PermissionDenied
+from .models import ChatSession, ChatLog, Sender
+from .serializers import ChatSessionSerializer, ChatLogSerializer
+from django.utils import timezone
 
-# Create your views here.
+
+class ChatSessionListCreateView(generics.ListCreateAPIView):
+    serializer_class = ChatSessionSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        return ChatSession.objects.filter(user=self.request.user).order_by('-created_at')
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
+
+class ChatMessageListCreateView(generics.ListCreateAPIView):
+    serializer_class = ChatLogSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        session_id = self.request.query_params.get('session_id')
+        if not session_id:
+            return ChatLog.objects.none()  # session_id가 없으면 빈 쿼리셋 반환
+
+        try:
+            session = ChatSession.objects.get(id=session_id)
+        except ChatSession.DoesNotExist:
+            return ChatLog.objects.none()
+
+        # 요청한 사용자가 세션의 소유주인지 확인
+        if session.user != self.request.user:
+            raise PermissionDenied("You do not have permission to view this chat session.")
+
+        return ChatLog.objects.filter(session_id=session_id).order_by('timestamp')
+
+    def perform_create(self, serializer):
+        serializer.save(
+            user=self.request.user,
+            sender=Sender.USER,
+            timestamp=timezone.now()
+        )
+

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/auth/', include('users.urls')),
+    path('api/chat/', include('chat.urls')),
 ]


### PR DESCRIPTION
  📝 작업 내역: chat 앱 기본 API 구현

  chat 앱의 핵심 기능인 채팅 세션과 메시지에 대한 CRUD(생성, 조회) API를 구현했습니다. 
  모든 API는 인증된 사용자만 접근 가능하며, 자신의 데이터에만 접근할 수 있도록 보안 로직이 적용되었습니다.

  1. 채팅 세션 (Chat Session)
   * `POST /api/chat/session`:
       * 새로운 채팅 세션을 생성합니다.
       * 요청 시 title을 받아, 현재 로그인한 사용자를 주인으로 하는 세션을 만듭니다.
   * `GET /api/chat/session`:
       * 현재 로그인한 사용자가 생성했던 모든 채팅 세션의 목록을 조회합니다.

  2. 채팅 메시지 (Chat Message)
   * `POST /api/chat/message`:
       * 특정 채팅 세션에 새로운 메시지를 보냅니다.
       * 요청 시 session ID와 message 내용을 받습니다.
       * 메시지를 보내는 sender는 항상 'user'로 자동 설정됩니다.
   * `GET /api/chat/message`:
       * URL 쿼리 파라미터로 받은 session_id에 해당하는 모든 메시지 목록을 시간순으로 조회합니다.
