### PR TITLE
GitHub Projects (beta) 연동 재구현: team-automation.yml에서 actions/add-to-project 액션을 사용하여 프로젝트 보드 자동 이동 기능을 재활성화

### DIFF
--- a/.github/workflows/team-automation.yml
+++ b/.github/workflows/team-automation.yml
@@ -29,13 +29,14 @@ jobs:
         numOfAssignee: 1
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     
-    # - name: 📊 Move to project board
-    #   if: github.event.action == 'opened'
-    #   uses: alex-page/github-project-automation-plus @v0.9.0 # Check for latest version
-    #   with:
-    #     project: Team Project Board # Replace with your actual project board name
-    #     column: 📋 Backlog # Replace with your actual column name
-    #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: 📊 Move to project board
+      if: github.event.action == 'opened'
+      uses: actions/add-to-project@v0.6.1 # Use the official action
+      with:
+        project-id: PVT_kwDODcPCt84BDOZc
+        field: Status # Name of your status field
+        value: 📋 Backlog # Name of the option
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # PR 자동 관리
   pr-management:
@@ -58,21 +59,23 @@ jobs:
         configuration-path: .github/labeler.yml
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     
-    # - name: 📊 Move PR to board
-    #   if: github.event.action == 'opened'
-    #   uses: alex-page/github-project-automation-plus @v0.9.0 # Check for latest version
-    #   with:
-    #     project: Team Project Board # Replace with your actual project board name
-    #     column: 👀 Review # Replace with your actual column name
-    #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: 📊 Move PR to board
+      if: github.event.action == 'opened'
+      uses: actions/add-to-project@v0.6.1
+      with:
+        project-id: PVT_kwDODcPCt84BDOZc
+        field: Status
+        value: 👀 Review
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     
-    # - name: 🎉 Celebrate merge
-    #   if: github.event.action == 'merged'
-    #   uses: alex-page/github-project-automation-plus @v0.9.0 # Check for latest version
-    #   with:
-    #     project: Team Project Board  # Replace with your actual project board name
-    #     column: ✅ Done # Replace with your actual column name
-    #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: 🎉 Celebrate merge
+      if: github.event.action == 'merged'
+      uses: actions/add-to-project@v0.6.1
+      with:
+        project-id: PVT_kwDODcPCt84BDOZc
+        field: Status
+        value: ✅ Done
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # 알림 시스템
   notifications:

--- a/.github/workflows/team-automation.yml
+++ b/.github/workflows/team-automation.yml
@@ -33,9 +33,9 @@ jobs:
       if: github.event.action == 'opened'
       uses: actions/add-to-project@v0.6.1 # Use the official action
       with:
-        project-id: PVT_kwDODcPCt84BDOZc
-        field: Status # Name of your status field
-        value: 📋 Backlog # Name of the option
+        project-url: https://github.com/orgs/oz-main-project-12th-team-3/projects/6
+        field-name: Status # Name of your status field
+        field-value: 📋 Backlog # Name of the option
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # PR 자동 관리
@@ -63,18 +63,18 @@ jobs:
       if: github.event.action == 'opened'
       uses: actions/add-to-project@v0.6.1
       with:
-        project-id: PVT_kwDODcPCt84BDOZc
-        field: Status
-        value: 👀 Review
+        project-url: https://github.com/orgs/oz-main-project-12th-team-3/projects/6
+        field-name: Status
+        field-value: 👀 Review
         github-token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: 🎉 Celebrate merge
       if: github.event.action == 'merged'
       uses: actions/add-to-project@v0.6.1
       with:
-        project-id: PVT_kwDODcPCt84BDOZc
-        field: Status
-        value: ✅ Done
+        project-url: https://github.com/orgs/oz-main-project-12th-team-3/projects/6
+        field-name: Status
+        field-value: ✅ Done
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # 알림 시스템


### PR DESCRIPTION
## 📝 변경 사항
  완료된 작업 요약:

   1. GitHub Secrets 설정 (추가 확인): DISCORD_WEBHOOK 등 필요한 시크릿 설정 (사용자 수동 작업)
   2. GitHub Project Board 설정: Team Project Board 생성 및 컬럼 설정. (사용자 수동 작업)
   3. 팀 구성원 GitHub ID 확인 및 설정: CODEOWNERS 및 기타 YAML 파일의 팀원 ID를 실제 GitHub ID로 업데이트
   4. GitHub Projects (beta) 연동 재구현: team-automation.yml에서 actions/add-to-project 액션을 사용하여 프로젝트 보드 자동 이동 기능을 재활성화

## 🎯 관련 이슈
- Closes #56 
- Related to #56 

## ✅ 변경 타입
- [✅] 🐛 버그 수정
- [✅] ✨ 새로운 기능
- [ ] 🛠️ 코드 개선
- [ ] 📝 문서 업데이트
- [ ] 🎨 스타일 변경
- [✅] 🚀 성능 개선

## 🧪 테스트
- [ ] 단위 테스트 추가/수정
- [✅] 통합 테스트 확인
- [✅] 수동 테스트 완료

## 📋 체크리스트
- [ ] 코드 리뷰 준비 완료
- [✅] 테스트 통과 확인
- [ ] 문서 업데이트 (필요시)
- [ ] 브랜치 체인지 없음

## 🖼️ 스크린샷 (UI 변경시)


## 🗣️ 기타 사항
